### PR TITLE
:recycle: Moved logic from model to domain service

### DIFF
--- a/src/Counter/application/create/CounterCreator.py
+++ b/src/Counter/application/create/CounterCreator.py
@@ -17,6 +17,9 @@ class CounterCreator:
 
     def create(self, counterId: CounterId, ownerId: UserId, private: CounterPrivate) -> None:
         counter = Counter.create(
-            counterId=counterId, ownerId=ownerId, private=private)
+            counterId=counterId, 
+            ownerId=ownerId, 
+            private=private
+        )
 
         self.repo.add(counter)

--- a/src/Counter/application/increment/CounterIncrementer.py
+++ b/src/Counter/application/increment/CounterIncrementer.py
@@ -1,5 +1,7 @@
 from ...domain.repositories.CounterRepository import CounterRepository
 
+from ...domain.services import CounterService
+
 from ...domain.entities import Counter
 
 from ...domain.value_objects import (
@@ -11,6 +13,7 @@ from ...domain.value_objects import (
 
 class CounterIncrementer:
     repo: CounterRepository
+    service: CounterService
 
     def __init__(self, repo: CounterRepository):
         self.repo = repo
@@ -18,4 +21,4 @@ class CounterIncrementer:
     def increment(self, counterId: CounterId, memberId: UserId) -> None:
         counter = self.repo.search(counterId)
 
-        counter.increment(memberId=memberId)
+        CounterService.increment(counter=counter, memberId=memberId)

--- a/src/Counter/application/join/CounterJoiner.py
+++ b/src/Counter/application/join/CounterJoiner.py
@@ -1,5 +1,7 @@
 from ...domain.repositories.CounterRepository import CounterRepository
 
+from ...domain.services import CounterService
+
 from ...domain.value_objects import (
     CounterId,
     UserId
@@ -15,4 +17,4 @@ class CounterJoiner:
     def join(self, counterId: CounterId, userId: UserId) -> None:
         counter = self.repo.search(counterId)
 
-        counter.join(userId)
+        CounterService.join(counter=counter, userId=userId)

--- a/src/Counter/application/kick/CounterKicker.py
+++ b/src/Counter/application/kick/CounterKicker.py
@@ -1,5 +1,7 @@
 from ...domain.repositories.CounterRepository import CounterRepository
 
+from ...domain.services import CounterService
+
 from ...domain.entities import Counter
 
 from ...domain.value_objects import (
@@ -17,4 +19,4 @@ class CounterKicker:
     def kick(self, ownerId: UserId, counterId: CounterId, memberId: UserId):
         counter = self.repo.search(counterId)
 
-        counter.kick(ownerId, memberId)
+        CounterService.kick(counter=counter, ownerId=ownerId, memberId=memberId)

--- a/src/Counter/application/leave/CounterLeaver.py
+++ b/src/Counter/application/leave/CounterLeaver.py
@@ -1,5 +1,7 @@
 from ...domain.repositories.CounterRepository import CounterRepository
 
+from ...domain.services import CounterService
+
 from ...domain.entities import Counter
 
 from ...domain.value_objects import (
@@ -17,4 +19,4 @@ class CounterLeaver:
     def leave(self, counterId: CounterId, memberId: UserId):
         counter = self.repo.search(counterId)
 
-        counter.leave(memberId)
+        CounterService.leave(counter=counter, memberId=memberId)

--- a/src/Counter/domain/entities/Counter.py
+++ b/src/Counter/domain/entities/Counter.py
@@ -59,31 +59,13 @@ class Counter:
                        private=private,
                        members=CounterMembers([ownerId]))
 
-    def increment(self, memberId: UserId) -> None:
-        if memberId not in self.members:
-            return
-        # domain event increment
-        self.__increment()
-
-    def __increment(self) -> None:
+    def increment(self) -> None:
         self.__status = CounterStatus(self.status + 1)
-
-    def join(self, userId: UserId) -> None:
-        if userId in self.members or self.private:
-            return
-        self.__members.add(userId)
-
-    def kick(self, ownerId: UserId, memberId: UserId) -> None:
-        if self.ownerId != ownerId:
-            return
-        self.__remove_member(memberId)
     
-    def leave(self, memberId: UserId) -> None:
-        self.__remove_member(memberId)
+    def join(self, memberId: UserId) -> None:
+        self.__members.add(memberId)
 
-    def __remove_member(self, memberId: UserId) -> None:
-        if not memberId in self.members:
-            return
+    def leave(self, memberId: UserId) -> None:
         self.__members.remove(memberId)
         
     def __hash__(self):

--- a/src/Counter/domain/services/__init__.py
+++ b/src/Counter/domain/services/__init__.py
@@ -1,0 +1,1 @@
+from .counter import CounterService

--- a/src/Counter/domain/services/counter.py
+++ b/src/Counter/domain/services/counter.py
@@ -1,0 +1,35 @@
+from ...domain.entities import Counter
+
+from ...domain.value_objects import (
+    UserId
+)
+
+
+class CounterService:
+    # i'll all of these as static method
+    # as by now i don't have any property for any service
+    
+    # the purpose of these service is orchestrate between domain model
+    # rather than orchestrate the use case (including interacting with repos)
+    @staticmethod
+    def increment(counter: Counter, memberId: UserId) -> None:
+        if memberId not in counter.members:
+            return
+        # domain event increment
+        counter.increment()
+    
+    @staticmethod
+    def join(counter: Counter, userId: UserId) -> None:
+        if userId in counter.members or counter.private:
+            return
+        counter.join(userId)
+    
+    @staticmethod
+    def kick(counter: Counter, ownerId: UserId, memberId: UserId) -> None:
+        if counter.ownerId != ownerId:
+            return
+        counter.leave(memberId)
+
+    @staticmethod
+    def leave(counter: Counter, memberId: UserId) -> None:
+        counter.leave(memberId)


### PR DESCRIPTION
In order to keep the domain entites small and to not push logic of various entities into one, i've implemented a **domain service**

By one, this service only *orchestrate* core logic between two or more entites, and by so it doesnt have any dependencies and it doesn't have to be injected (only implements staticmethods).